### PR TITLE
Update from update/NikitaSkrynnik/sdk-kernel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	git.fd.io/govpp.git v0.3.6-0.20210927044411-385ccc0d8ba9
 	github.com/NikitaSkrynnik/api v1.0.1-0.20230711064101-51396a9946fc
 	github.com/NikitaSkrynnik/govpp v0.0.0-20230711065959-e2b65ca34c90
-	github.com/NikitaSkrynnik/sdk v0.5.1-0.20230711090343-6d55d1862089
-	github.com/NikitaSkrynnik/sdk-kernel v0.0.0-20230711090551-5ebfd09e8d29
+	github.com/NikitaSkrynnik/sdk v0.5.1-0.20230712060804-d605cde9ae50
+	github.com/NikitaSkrynnik/sdk-kernel v0.0.0-20230712060952-0c012023b36c
 	github.com/cilium/ebpf v0.10.0
 	github.com/edwarnicke/serialize v1.0.7
 	github.com/golang/protobuf v1.5.3

--- a/go.sum
+++ b/go.sum
@@ -39,10 +39,10 @@ github.com/NikitaSkrynnik/api v1.0.1-0.20230711064101-51396a9946fc h1:yMHA//UiNx
 github.com/NikitaSkrynnik/api v1.0.1-0.20230711064101-51396a9946fc/go.mod h1:6va68ed+AyiYRSNK/RQ91XEZdYHDfb6xVyBzjVhlGVs=
 github.com/NikitaSkrynnik/govpp v0.0.0-20230711065959-e2b65ca34c90 h1:xL8G0B9PpmeXuOR3fjXR6n1TyX8NGVCfgf3A3QzwXCA=
 github.com/NikitaSkrynnik/govpp v0.0.0-20230711065959-e2b65ca34c90/go.mod h1:WAhJ/KR1mbvVNd2XZhglDAw2nm5xDwjFKqwxOLDHMRs=
-github.com/NikitaSkrynnik/sdk v0.5.1-0.20230711090343-6d55d1862089 h1:kNCiDrhrJpzNkgJzY7t4v22x6DVIGNO1tJRwYlHVxQE=
-github.com/NikitaSkrynnik/sdk v0.5.1-0.20230711090343-6d55d1862089/go.mod h1:zmGb/Hc6WN95sfc0vf5cz6IdbsaY/t76jtFlaMnIrB8=
-github.com/NikitaSkrynnik/sdk-kernel v0.0.0-20230711090551-5ebfd09e8d29 h1:8osgrh8va8+4gkrdJZpVzvx8cTrzDWSneEv5atDIwWw=
-github.com/NikitaSkrynnik/sdk-kernel v0.0.0-20230711090551-5ebfd09e8d29/go.mod h1:AAEC3efcocD42XvychQpQSM9L7rccXLc1xdzHN1sj6I=
+github.com/NikitaSkrynnik/sdk v0.5.1-0.20230712060804-d605cde9ae50 h1:AsHbrecPhWczmLWoDcPVRVSpJRhiHE+yNBmCnxUGDYk=
+github.com/NikitaSkrynnik/sdk v0.5.1-0.20230712060804-d605cde9ae50/go.mod h1:zmGb/Hc6WN95sfc0vf5cz6IdbsaY/t76jtFlaMnIrB8=
+github.com/NikitaSkrynnik/sdk-kernel v0.0.0-20230712060952-0c012023b36c h1:ZxVrBPr7AkTATmVbbWNBAAnc4v9pRdypFgeYHIR+JbU=
+github.com/NikitaSkrynnik/sdk-kernel v0.0.0-20230712060952-0c012023b36c/go.mod h1:67BJh4DJkBQtXPNntednu18RldS61uIu3LONPlQWc0w=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OneOfOne/xxhash v1.2.8 h1:31czK/TI9sNkxIKfaUfGlU47BAxQ0ztGgd9vPyqimf8=
 github.com/OneOfOne/xxhash v1.2.8/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=


### PR DESCRIPTION
Update go.mod and go.sum to latest version from NikitaSkrynnik/sdk-kernel@main
PR link: https://github.com/NikitaSkrynnik/sdk-kernel/pull/9
Commit: 0c01202
Author: Nikita Skrynnik
Date: 2023-07-12 17:09:52 +1100
Message:
  - Update go.mod and go.sum to latest version from NikitaSkrynnik/sdk@main